### PR TITLE
Added support for extracted ISO and wii patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Rom Hack Compiler
 
-A tool that makes compiling Rom Hacks for Wii games easy.
+A tool that makes compiling Rom Hacks for GameCube/Wii games easy.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Rom Hack Compiler
 
-A tool that makes compiling Rom Hacks for GameCube games easy.
+A tool that makes compiling Rom Hacks for Wii games easy.

--- a/backend/src/assembler.rs
+++ b/backend/src/assembler.rs
@@ -104,7 +104,7 @@ impl<'a> Assembler<'a> {
     }
 
     fn parse_program_counter_label(&self, line: &str) -> Result<u32, Error> {
-        let mut line = line[..line.len() - 1].trim_left();
+        let mut line = line[..line.len() - 1].trim_start();
         let mut address = 0u32;
         let mut is_add = true;
         loop {
@@ -113,11 +113,11 @@ impl<'a> Assembler<'a> {
                 .next()
                 .ok_or_else(|| err_msg("Expected integer literal or symbol"))?
             {
-                '0'...'9' | '-' => {
+                '0'..='9' | '-' => {
                     let len = line
                         .char_indices()
                         .take_while(|&(i, c)| match c {
-                            '0'...'9' | 'A'...'F' | 'a'...'f' | '_' => true,
+                            '0'..='9' | 'A'..='F' | 'a'..='f' | '_' => true,
                             '-' if i == 0 => true,
                             'x' if i == 1 => true,
                             _ => false,
@@ -157,14 +157,14 @@ impl<'a> Assembler<'a> {
             } else {
                 address.wrapping_sub(val)
             };
-            line = line.trim_left();
+            line = line.trim_start();
             is_add = match line.chars().next() {
                 Some('+') => true,
                 Some('-') => false,
                 None => return Ok(address),
                 _ => bail!("Expected + or - operator but found \"{}\"", line),
             };
-            line = line[1..].trim_left();
+            line = line[1..].trim_start();
         }
     }
 }

--- a/backend/src/demangle.rs
+++ b/backend/src/demangle.rs
@@ -128,7 +128,7 @@ fn parse_type(text: &str) -> Result<(Option<Type>, &str), Cow<'static, str>> {
         Some('d') => Type::Normal(false, "f64"),
         Some('b') => Type::Normal(false, "bool"),
         Some('e') => Type::VarArgs,
-        Some('0'...'9') => {
+        Some('0'..='9') => {
             let (count, remaining) = parse_count(original_text)?;
             text = remaining;
 

--- a/backend/src/framework_map.rs
+++ b/backend/src/framework_map.rs
@@ -24,7 +24,7 @@ pub fn create(
     writeln!(file, ".text section layout")?;
 
     for section in sections {
-        let mut section_name_buf;
+        let section_name_buf;
         let section_name = section.section_name;
         let section_name = if section_name.starts_with(".text.")
             && section.kind == SectionKind::TextSection

--- a/backend/src/iso/mod.rs
+++ b/backend/src/iso/mod.rs
@@ -1,6 +1,8 @@
 //! Based on http://www.gc-forever.com/yagcd/chap13.html#sec13
 //! and https://github.com/LordNed/WArchive-Tools
 
+use std::path::PathBuf;
+
 pub mod reader;
 pub mod virtual_file_system;
 pub mod writer;
@@ -40,4 +42,9 @@ struct FstEntry<'a> {
     file_offset_parent_dir: usize,
     file_size_next_dir_index: usize,
     file_name_offset: usize,
+}
+
+pub enum IsoBuf {
+    Raw(Vec<u8>),
+    Extracted(PathBuf)
 }

--- a/backend/src/iso/reader.rs
+++ b/backend/src/iso/reader.rs
@@ -125,11 +125,11 @@ pub fn load_iso<'a>(buf: &'a IsoBuf) -> Result<Directory<'a>, Error> {
             let mut sys_path = path.clone();
             sys_path.push("sys");
 
-            add_file_to_dir(&sys_path, "bi2.bin", "iso.hdr", &mut sys_data)?;
+            add_file_to_dir(&sys_path, "boot.bin", "iso.hdr", &mut sys_data)?;
             add_file_to_dir(&sys_path, "apploader.img", "AppLoader.ldr", &mut sys_data)?;
             add_file_to_dir(&sys_path, "main.dol", "Start.dol", &mut sys_data)?;
-            add_file_to_dir(&sys_path, "boot.bin", "Game.toc", &mut sys_data)?;
-            add_file_to_dir(&sys_path, "fst.bin", "fst.bin", &mut sys_data)?;
+            add_file_to_dir(&sys_path, "fst.bin", "Game.toc", &mut sys_data)?;
+            add_file_to_dir(&sys_path, "bi2.bin", "bi2.bin", &mut sys_data)?;
             
             root_dir.children.push(Node::Directory(Box::new(sys_data)));
 

--- a/backend/src/iso/reader.rs
+++ b/backend/src/iso/reader.rs
@@ -3,7 +3,7 @@ use super::{consts::*, FstEntry, FstNodeType, IsoBuf};
 use byteorder::{ByteOrder, BE};
 use failure::{Error, ResultExt};
 use std::fs;
-use std::io::{Read, Result as IOResult};
+use std::io::{Read};
 use std::path::{Path, PathBuf};
 use std::str;
 
@@ -13,6 +13,7 @@ pub fn load_iso_buf<P: AsRef<Path>>(path: &P) -> Result<IsoBuf, Error> {
     } else {
         let mut path_buf = PathBuf::new();
         path_buf.push(path);
+        path_buf.push("DATA");
         Ok(IsoBuf::Extracted(path_buf))
     }
 }
@@ -114,29 +115,29 @@ pub fn load_iso<'a>(buf: &'a IsoBuf) -> Result<Directory<'a>, Error> {
             let mut disc_data = Directory::new("&&discdata");
             let mut root_data = Directory::new("&&rootdata");
 
-            add_file_to_dir(&path, "cert.bin", "cert.bin", &mut root_data);
-            add_file_to_dir(&path, "h3.bin", "h3.bin", &mut root_data);
-            add_file_to_dir(&path, "ticket.bin", "ticket.bin", &mut root_data);
-            add_file_to_dir(&path, "tmd.bin", "tmd.bin", &mut root_data);
+            add_file_to_dir(&path, "cert.bin", "cert.bin", &mut root_data)?;
+            add_file_to_dir(&path, "h3.bin", "h3.bin", &mut root_data)?;
+            add_file_to_dir(&path, "ticket.bin", "ticket.bin", &mut root_data)?;
+            add_file_to_dir(&path, "tmd.bin", "tmd.bin", &mut root_data)?;
 
             root_dir.children.push(Node::Directory(Box::new(root_data)));
             
             let mut sys_path = path.clone();
             sys_path.push("sys");
 
-            add_file_to_dir(&sys_path, "bi2.bin", "iso.hdr", &mut sys_data);
-            add_file_to_dir(&sys_path, "apploader.img", "AppLoader.ldr", &mut sys_data);
-            add_file_to_dir(&sys_path, "main.dol", "Start.dol", &mut sys_data);
-            add_file_to_dir(&sys_path, "boot.bin", "Game.toc", &mut sys_data);
-            add_file_to_dir(&sys_path, "fst.bin", "fst.bin", &mut sys_data);
+            add_file_to_dir(&sys_path, "bi2.bin", "iso.hdr", &mut sys_data)?;
+            add_file_to_dir(&sys_path, "apploader.img", "AppLoader.ldr", &mut sys_data)?;
+            add_file_to_dir(&sys_path, "main.dol", "Start.dol", &mut sys_data)?;
+            add_file_to_dir(&sys_path, "boot.bin", "Game.toc", &mut sys_data)?;
+            add_file_to_dir(&sys_path, "fst.bin", "fst.bin", &mut sys_data)?;
             
             root_dir.children.push(Node::Directory(Box::new(sys_data)));
 
             let mut disc_path = path.clone();
             disc_path.push("disc");
 
-            add_file_to_dir(&disc_path, "header.bin", "header.bin", &mut disc_data);
-            add_file_to_dir(&disc_path, "region.bin", "region.bin", &mut disc_data);
+            add_file_to_dir(&disc_path, "header.bin", "header.bin", &mut disc_data)?;
+            add_file_to_dir(&disc_path, "region.bin", "region.bin", &mut disc_data)?;
 
             root_dir.children.push(Node::Directory(Box::new(disc_data)));
 

--- a/backend/src/iso/reader.rs
+++ b/backend/src/iso/reader.rs
@@ -1,107 +1,163 @@
 use super::virtual_file_system::{Directory, File, Node};
-use super::{consts::*, FstEntry, FstNodeType};
+use super::{consts::*, FstEntry, FstNodeType, IsoBuf};
 use byteorder::{ByteOrder, BE};
 use failure::{Error, ResultExt};
 use std::fs;
 use std::io::{Read, Result as IOResult};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str;
 
-pub fn load_iso_buf<P: AsRef<Path>>(path: P) -> IOResult<Vec<u8>> {
-    let mut file = fs::File::open(path)?;
-    let len = file.metadata()?.len();
-    let mut buf = Vec::with_capacity(len as usize + 1);
-    file.read_to_end(&mut buf)?;
-    Ok(buf)
+pub fn load_iso_buf<P: AsRef<Path>>(path: &P) -> Result<IsoBuf, Error> {
+    if path.as_ref().is_file() {
+        Ok(IsoBuf::Raw(read_binary(path).context(format!("couldn't open ISO at \"{:?}\"", path.as_ref().to_str()))?))
+    } else {
+        let mut path_buf = PathBuf::new();
+        path_buf.push(path);
+        Ok(IsoBuf::Extracted(path_buf))
+    }
 }
 
-pub fn load_iso<'a>(buf: &'a [u8]) -> Result<Directory<'a>, Error> {
-    let fst_offset = BE::read_u32(&buf[OFFSET_FST_OFFSET..]) as usize;
-    let mut pos = fst_offset;
-    let num_entries = BE::read_u32(&buf[fst_offset + 8..]) as usize;
-    let string_table_offset = num_entries * 0xC;
+pub fn load_iso<'a>(buf: &'a IsoBuf) -> Result<Directory<'a>, Error> {
+    match buf {
+        IsoBuf::Raw(buf) => {
+            let buf = buf.as_slice();
+            let fst_offset = BE::read_u32(&buf[OFFSET_FST_OFFSET..]) as usize;
+            let mut pos = fst_offset;
+            let num_entries = BE::read_u32(&buf[fst_offset + 8..]) as usize;
+            let string_table_offset = num_entries * 0xC;
 
-    let mut fst_entries = Vec::with_capacity(num_entries);
-    for _ in 0..num_entries {
-        let kind = if buf[pos] == 0 {
-            FstNodeType::File
-        } else {
-            FstNodeType::Directory
-        };
-        pos += 2;
+            let mut fst_entries = Vec::with_capacity(num_entries);
+            for _ in 0..num_entries {
+                let kind = if buf[pos] == 0 {
+                    FstNodeType::File
+                } else {
+                    FstNodeType::Directory
+                };
+                pos += 2;
 
-        let cur_pos = pos;
-        let string_offset = BE::read_u16(&buf[pos..]) as usize;
+                let cur_pos = pos;
+                let string_offset = BE::read_u16(&buf[pos..]) as usize;
 
-        pos = string_offset + string_table_offset + fst_offset;
-        let mut end = pos;
-        while buf[end] != 0 {
-            end += 1;
-        }
-        let relative_file_name =
-            str::from_utf8(&buf[pos..end]).context("Couldn't parse the relative file name")?;
+                pos = string_offset + string_table_offset + fst_offset;
+                let mut end = pos;
+                while buf[end] != 0 {
+                    end += 1;
+                }
+                let relative_file_name =
+                    str::from_utf8(&buf[pos..end]).context("Couldn't parse the relative file name")?;
 
-        pos = cur_pos + 2;
-        let file_offset_parent_dir = BE::read_u32(&buf[pos..]) as usize;
-        let file_size_next_dir_index = BE::read_u32(&buf[pos + 4..]) as usize;
-        pos += 8;
+                pos = cur_pos + 2;
+                let file_offset_parent_dir = BE::read_u32(&buf[pos..]) as usize;
+                let file_size_next_dir_index = BE::read_u32(&buf[pos + 4..]) as usize;
+                pos += 8;
 
-        fst_entries.push(FstEntry {
-            kind,
-            relative_file_name,
-            file_offset_parent_dir,
-            file_size_next_dir_index,
-            file_name_offset: 0,
-        });
-    }
-
-    let mut root_dir = Directory::new("root");
-    let mut sys_data = Directory::new("&&systemdata");
-
-    sys_data
-        .children
-        .push(Node::File(File::new("iso.hdr", &buf[..HEADER_LENGTH])));
-
-    let dol_offset = BE::read_u32(&buf[OFFSET_DOL_OFFSET..]) as usize;
-
-    sys_data.children.push(Node::File(File::new(
-        "AppLoader.ldr",
-        &buf[HEADER_LENGTH..dol_offset],
-    )));
-
-    sys_data.children.push(Node::File(File::new(
-        "Start.dol",
-        &buf[dol_offset..fst_offset],
-    )));
-
-    let fst_size = BE::read_u32(&buf[OFFSET_FST_SIZE..]) as usize;
-    sys_data.children.push(Node::File(File::new(
-        "Game.toc",
-        &buf[fst_offset..][..fst_size],
-    )));
-
-    root_dir.children.push(Node::Directory(Box::new(sys_data)));
-
-    let mut count = 1;
-
-    while count < num_entries {
-        let entry = &fst_entries[count];
-        if fst_entries[count].kind == FstNodeType::Directory {
-            let mut dir = Directory::new(entry.relative_file_name);
-
-            while count < entry.file_size_next_dir_index - 1 {
-                count = get_dir_structure_recursive(count + 1, &fst_entries, &mut dir, buf);
+                fst_entries.push(FstEntry {
+                    kind,
+                    relative_file_name,
+                    file_offset_parent_dir,
+                    file_size_next_dir_index,
+                    file_name_offset: 0,
+                });
             }
 
-            root_dir.children.push(Node::Directory(Box::new(dir)));
-        } else {
-            let file = get_file_data(&fst_entries[count], buf);
-            root_dir.children.push(Node::File(file));
-        }
-        count += 1;
-    }
+            let mut root_dir = Directory::new("root");
+            let mut sys_data = Directory::new("&&systemdata");
 
-    Ok(root_dir)
+            sys_data
+                .children
+                .push(Node::File(File::new("iso.hdr", &buf[..HEADER_LENGTH])));
+    
+            let dol_offset = BE::read_u32(&buf[OFFSET_DOL_OFFSET..]) as usize;
+
+            sys_data.children.push(Node::File(File::new(
+                "AppLoader.ldr",
+                &buf[HEADER_LENGTH..dol_offset],
+            )));
+
+            sys_data.children.push(Node::File(File::new(
+                "Start.dol",
+                &buf[dol_offset..fst_offset],
+            )));
+
+            let fst_size = BE::read_u32(&buf[OFFSET_FST_SIZE..]) as usize;
+            sys_data.children.push(Node::File(File::new(
+                "Game.toc",
+                &buf[fst_offset..][..fst_size],
+            )));
+
+            root_dir.children.push(Node::Directory(Box::new(sys_data)));
+
+            let mut count = 1;
+
+            while count < num_entries {
+                let entry = &fst_entries[count];
+                if fst_entries[count].kind == FstNodeType::Directory {
+                    let mut dir = Directory::new(entry.relative_file_name);
+
+                    while count < entry.file_size_next_dir_index - 1 {
+                        count = get_dir_structure_recursive(count + 1, &fst_entries, &mut dir, buf);
+                    }
+
+                    root_dir.children.push(Node::Directory(Box::new(dir)));
+                } else {
+                    let file = get_file_data(&fst_entries[count], buf);
+                    root_dir.children.push(Node::File(file));
+                }
+                count += 1;
+            }
+
+            Ok(root_dir)
+        }
+        IsoBuf::Extracted(path) => {
+            let mut root_dir = Directory::new("root");
+            let mut sys_data = Directory::new("&&systemdata");
+            let mut disc_data = Directory::new("&&discdata");
+            let mut root_data = Directory::new("&&rootdata");
+
+            add_file_to_dir(&path, "cert.bin", "cert.bin", &mut root_data);
+            add_file_to_dir(&path, "h3.bin", "h3.bin", &mut root_data);
+            add_file_to_dir(&path, "ticket.bin", "ticket.bin", &mut root_data);
+            add_file_to_dir(&path, "tmd.bin", "tmd.bin", &mut root_data);
+
+            root_dir.children.push(Node::Directory(Box::new(root_data)));
+            
+            let mut sys_path = path.clone();
+            sys_path.push("sys");
+
+            add_file_to_dir(&sys_path, "bi2.bin", "iso.hdr", &mut sys_data);
+            add_file_to_dir(&sys_path, "apploader.img", "AppLoader.ldr", &mut sys_data);
+            add_file_to_dir(&sys_path, "main.dol", "Start.dol", &mut sys_data);
+            add_file_to_dir(&sys_path, "boot.bin", "Game.toc", &mut sys_data);
+            add_file_to_dir(&sys_path, "fst.bin", "fst.bin", &mut sys_data);
+            
+            root_dir.children.push(Node::Directory(Box::new(sys_data)));
+
+            let mut disc_path = path.clone();
+            disc_path.push("disc");
+
+            add_file_to_dir(&disc_path, "header.bin", "header.bin", &mut disc_data);
+            add_file_to_dir(&disc_path, "region.bin", "region.bin", &mut disc_data);
+
+            root_dir.children.push(Node::Directory(Box::new(disc_data)));
+
+            let mut files_path = path.clone();
+            files_path.push("files");
+
+            get_dir_structure_recursive_fs(files_path, &mut root_dir)?;
+
+            Ok(root_dir)
+        }
+    }
+}
+
+fn add_file_to_dir(dir_path: &PathBuf, fs_name: &str, given_name: &str, dir: &mut Directory) -> Result<(), Error> {
+    let mut file_path = dir_path.clone();
+    file_path.push(fs_name);
+    dir.children.push(Node::File(File::new(
+        given_name,
+        read_binary(&file_path)?,
+    )));
+    Ok(())
 }
 
 fn get_dir_structure_recursive<'a>(
@@ -128,7 +184,30 @@ fn get_dir_structure_recursive<'a>(
     cur_index
 }
 
+fn get_dir_structure_recursive_fs<'a>(path: PathBuf, parent_dir: &mut Directory<'a>) -> Result<(), Error> {
+    for entry in path.read_dir().context(format!("Couldn't read dir of \"{:?}\"", path.to_str()))? {
+        let entry = entry?;
+        let filename = entry.file_name();
+        if entry.metadata().context(format!("Couldn't fetch metadata of entry \"{:?}\"", entry.path().to_str()))?.is_dir() {
+            let mut dir = Directory::new(filename.to_str().unwrap());
+            get_dir_structure_recursive_fs(entry.path(), &mut dir)?;
+            parent_dir.children.push(Node::Directory(Box::new(dir)));
+        } else {
+            parent_dir.children.push(Node::File(File::new(filename.to_str().unwrap(), read_binary(&entry.path())?)));
+        }
+    }
+    Ok(())
+}
+
 fn get_file_data<'a>(fst_data: &FstEntry<'a>, buf: &'a [u8]) -> File<'a> {
     let data = &buf[fst_data.file_offset_parent_dir..][..fst_data.file_size_next_dir_index];
     File::new(fst_data.relative_file_name, data)
+}
+
+fn read_binary<P: AsRef<Path>>(path: &P) -> Result<Vec<u8>, Error> {
+    let mut file = fs::File::open(path).context(format!("Couldn't open \"{:?}\"", path.as_ref().to_str()))?;
+    let len = file.metadata().context(format!("Couldn't fetch metadata of \"{:?}\"", path.as_ref().to_str()))?.len();
+    let mut buf = Vec::with_capacity(len as usize + 1);
+    file.read_to_end(&mut buf).context(format!("Couldn't read \"{:?}\"", path.as_ref().to_str()))?;
+    Ok(buf)
 }

--- a/backend/src/iso/virtual_file_system.rs
+++ b/backend/src/iso/virtual_file_system.rs
@@ -42,14 +42,14 @@ impl<'a> Node<'a> {
 
 #[derive(Debug)]
 pub struct Directory<'a> {
-    pub name: &'a str,
+    pub name: String,
     pub children: Vec<Node<'a>>,
 }
 
 impl<'a> Directory<'a> {
-    pub fn new(name: &'a str) -> Directory<'a> {
+    pub fn new(name: &str) -> Directory<'a> {
         Self {
-            name,
+            name: String::from(name),
             children: Vec::new(),
         }
     }
@@ -138,14 +138,14 @@ impl<'a> Directory<'a> {
 }
 
 pub struct File<'a> {
-    pub name: &'a str,
+    pub name: String,
     pub data: Cow<'a, [u8]>,
 }
 
 impl<'a> File<'a> {
-    pub fn new<A: Into<Cow<'a, [u8]>>>(name: &'a str, data: A) -> File<'a> {
+    pub fn new<A: Into<Cow<'a, [u8]>>>(name: &str, data: A) -> File<'a> {
         Self {
-            name,
+            name: String::from(name),
             data: data.into(),
         }
     }

--- a/backend/src/iso/virtual_file_system.rs
+++ b/backend/src/iso/virtual_file_system.rs
@@ -137,7 +137,7 @@ impl<'a> Directory<'a> {
     }
 
     // TODO NLL This is really bad
-    pub fn resolve_and_create_path(&mut self, path: &'a str) -> &mut File<'a> {
+    pub fn resolve_and_create_path(&mut self, path: &String) -> &mut File<'a> {
         let mut splits = path.splitn(2, '/');
         if let (Some(folder), Some(sub_path)) = (splits.next(), splits.next()) {
             if !self
@@ -154,20 +154,20 @@ impl<'a> Directory<'a> {
                 .filter_map(|c| c.as_directory_mut())
                 .find(|d| d.name == folder)
                 .unwrap()
-                .resolve_and_create_path(sub_path)
+                .resolve_and_create_path(&String::from(sub_path))
         } else {
             if !self
                 .children
                 .iter_mut()
                 .filter_map(|c| c.as_file_mut())
-                .any(|f| f.name == path)
+                .any(|f| f.name == *path)
             {
                 self.children.push(Node::File(File::new(path, Vec::new())));
             }
             self.children
                 .iter_mut()
                 .filter_map(|c| c.as_file_mut())
-                .find(|f| f.name == path)
+                .find(|f| f.name == *path)
                 .unwrap()
         }
     }

--- a/backend/src/iso/virtual_file_system.rs
+++ b/backend/src/iso/virtual_file_system.rs
@@ -8,6 +8,13 @@ pub enum Node<'a> {
 }
 
 impl<'a> Node<'a> {
+    pub fn name(&self) -> &String {
+        match self {
+            Node::Directory(dir) => &dir.name,
+            Node::File(file) => &file.name,
+        }
+    }
+
     pub fn as_directory(&self) -> Option<&Directory<'a>> {
         if let &Node::Directory(ref dir) = self {
             Some(dir)

--- a/backend/src/iso/writer.rs
+++ b/backend/src/iso/writer.rs
@@ -121,7 +121,7 @@ pub fn write_fs(path: PathBuf, root: &Directory) -> Result<(), Error> {
     path.push("DATA");
     fs::create_dir_all(&path)?;
     // TODO Write the function
-    let (_root_index, root_dir, _) = write_data_dir(None, "&&rootdata", root, &path)?;
+    let (root_index, root_dir, _) = write_data_dir(None, "&&rootdata", root, &path)?;
 
     write_data_file(&path, "cert.bin", "cert.bin", &root_dir)?;
     write_data_file(&path, "h3.bin", "h3.bin", &root_dir)?;
@@ -130,13 +130,13 @@ pub fn write_fs(path: PathBuf, root: &Directory) -> Result<(), Error> {
 
     let (sys_index, sys_dir, sys_path) = write_data_dir(Some("sys"), "&&systemdata", root, &path)?;
 
-    write_data_file(&sys_path, "bi2.bin", "iso.hdr", &sys_dir)?;
+    write_data_file(&sys_path, "boot.bin", "iso.hdr", &sys_dir)?;
     write_data_file(&sys_path, "apploader.img", "AppLoader.ldr", &sys_dir)?;
     write_data_file(&sys_path, "main.dol", "Start.dol", &sys_dir)?;
-    write_data_file(&sys_path, "boot.bin", "Game.toc", &sys_dir)?;
-    write_data_file(&sys_path, "fst.bin", "fst.bin", &sys_dir)?;
+    write_data_file(&sys_path, "fst.bin", "Game.toc", &sys_dir)?;
+    write_data_file(&sys_path, "bi2.bin", "bi2.bin", &sys_dir)?;
 
-    let (_disc_index, disc_dir, disc_path) = write_data_dir(Some("disc"), "&&discdata", root, &path)?;
+    let (disc_index, disc_dir, disc_path) = write_data_dir(Some("disc"), "&&discdata", root, &path)?;
 
     write_data_file(&disc_path, "header.bin", "header.bin", &disc_dir)?;
     write_data_file(&disc_path, "region.bin", "region.bin", &disc_dir)?;
@@ -148,7 +148,7 @@ pub fn write_fs(path: PathBuf, root: &Directory) -> Result<(), Error> {
         .children
         .iter()
         .enumerate()
-        .filter(|&(i, _)| i != sys_index)
+        .filter(|&(i, _)| i != root_index && i != sys_index && i != disc_index)
     {
         write_files_recursive(node, &files_path)?;
     }

--- a/backend/src/iso/writer.rs
+++ b/backend/src/iso/writer.rs
@@ -117,31 +117,33 @@ where
 }
 
 pub fn write_fs(path: PathBuf, root: &Directory) -> Result<(), Error> {
-    fs::create_dir_all(&path);
+    let mut path = path.clone();
+    path.push("DATA");
+    fs::create_dir_all(&path)?;
     // TODO Write the function
-    let (root_index, root_dir, _) = write_data_dir(None, "&&rootdata", root, &path)?;
+    let (_root_index, root_dir, _) = write_data_dir(None, "&&rootdata", root, &path)?;
 
-    write_data_file(&path, "cert.bin", "cert.bin", &root_dir);
-    write_data_file(&path, "h3.bin", "h3.bin", &root_dir);
-    write_data_file(&path, "ticket.bin", "ticket.bin", &root_dir);
-    write_data_file(&path, "tmd.bin", "tmd.bin", &root_dir);
+    write_data_file(&path, "cert.bin", "cert.bin", &root_dir)?;
+    write_data_file(&path, "h3.bin", "h3.bin", &root_dir)?;
+    write_data_file(&path, "ticket.bin", "ticket.bin", &root_dir)?;
+    write_data_file(&path, "tmd.bin", "tmd.bin", &root_dir)?;
 
     let (sys_index, sys_dir, sys_path) = write_data_dir(Some("sys"), "&&systemdata", root, &path)?;
 
-    write_data_file(&sys_path, "bi2.bin", "iso.hdr", &sys_dir);
-    write_data_file(&sys_path, "apploader.img", "AppLoader.ldr", &sys_dir);
-    write_data_file(&sys_path, "main.dol", "Start.dol", &sys_dir);
-    write_data_file(&sys_path, "boot.bin", "Game.toc", &sys_dir);
-    write_data_file(&sys_path, "fst.bin", "fst.bin", &sys_dir);
+    write_data_file(&sys_path, "bi2.bin", "iso.hdr", &sys_dir)?;
+    write_data_file(&sys_path, "apploader.img", "AppLoader.ldr", &sys_dir)?;
+    write_data_file(&sys_path, "main.dol", "Start.dol", &sys_dir)?;
+    write_data_file(&sys_path, "boot.bin", "Game.toc", &sys_dir)?;
+    write_data_file(&sys_path, "fst.bin", "fst.bin", &sys_dir)?;
 
-    let (disc_index, disc_dir, disc_path) = write_data_dir(Some("disc"), "&&discdata", root, &path)?;
+    let (_disc_index, disc_dir, disc_path) = write_data_dir(Some("disc"), "&&discdata", root, &path)?;
 
-    write_data_file(&disc_path, "header.bin", "header.bin", &disc_dir);
-    write_data_file(&disc_path, "region.bin", "region.bin", &disc_dir);
+    write_data_file(&disc_path, "header.bin", "header.bin", &disc_dir)?;
+    write_data_file(&disc_path, "region.bin", "region.bin", &disc_dir)?;
 
     let mut files_path = path.clone();
     files_path.push("files");
-    fs::create_dir_all(&files_path);
+    fs::create_dir_all(&files_path)?;
     for (_, node) in root
         .children
         .iter()
@@ -165,7 +167,7 @@ fn write_data_dir<'a>(dir_fs_name: Option<&str>, dir_given_name: &str, parent_di
     let mut dir_path = path.clone();
     if let Some(dir_fs_name) = dir_fs_name {
         dir_path.push(dir_fs_name);
-        fs::create_dir_all(&dir_path);
+        fs::create_dir_all(&dir_path)?;
     }
     Ok((dir_index, dir, dir_path))
 }

--- a/backend/src/iso/writer.rs
+++ b/backend/src/iso/writer.rs
@@ -3,7 +3,7 @@ use super::{consts::*, FstEntry, FstNodeType};
 use byteorder::{WriteBytesExt, BE};
 use failure::{err_msg, Error, ResultExt};
 use std::io::{Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::{PathBuf};
 use std::fs;
 
 pub fn write_iso<W>(mut writer: W, root: &Directory) -> Result<(), Error>

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -174,6 +174,50 @@ pub fn open_config_from_patch<R: Read + Seek>(
     Ok((zip, buffer, config))
 }
 
+fn add_file_to_zip(
+    index: usize,
+    iso_path: &String,
+    actual_path: &PathBuf,
+    zip: &mut ZipWriter<BufWriter<File>>,
+    new_map: &mut HashMap<String, PathBuf>
+) -> Result<(), Error> {
+    let zip_path = format!("replace{}.dat", index);
+    new_map.insert(iso_path.clone(), PathBuf::from(&zip_path));
+    zip.start_file(zip_path, FileOptions::default())
+        .context("Failed creating a new patch file entry")?;
+
+    zip.write_all(&fs::read(actual_path).with_context(|_| {
+        format!(
+            "Couldn't read the file \"{}\" to store it in the patch.",
+            actual_path.display()
+        )
+    })?)
+    .context("Failed storing a file in the patch")?;
+    Ok(())
+}
+
+fn add_entry_to_zip(
+    index: &mut usize,
+    iso_path: &String,
+    actual_path: &PathBuf,
+    zip: &mut ZipWriter<BufWriter<File>>,
+    new_map: &mut HashMap<String, PathBuf>
+) -> Result<(), Error> {
+    if actual_path.is_file() {
+        *index = *index + 1;
+        add_file_to_zip(*index, iso_path, actual_path, zip, new_map)?;
+    } else if actual_path.is_dir() {
+        for entry in fs::read_dir(actual_path)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let file_name = entry_path.file_name().expect("Entry has no name");
+            let iso_path = String::from(iso_path) + &String::from('/') + &String::from(file_name.to_str().unwrap());
+            add_entry_to_zip(index, &iso_path, &entry_path, zip, new_map)?;
+        }
+    }
+    Ok(())
+}
+
 fn build_patch<P: KeyValPrint>(
     printer: &P,
     compiled_library: Vec<u8>,
@@ -189,19 +233,9 @@ fn build_patch<P: KeyValPrint>(
     printer.print(None, "Storing", "replacement files");
 
     let mut new_map = HashMap::new();
-    for (index, (iso_path, actual_path)) in config.files.iter().enumerate() {
-        let zip_path = format!("replace{}.dat", index);
-        new_map.insert(iso_path.clone(), PathBuf::from(&zip_path));
-        zip.start_file(zip_path, FileOptions::default())
-            .context("Failed creating a new patch file entry")?;
-
-        zip.write_all(&fs::read(actual_path).with_context(|_| {
-            format!(
-                "Couldn't read the file \"{}\" to store it in the patch.",
-                actual_path.display()
-            )
-        })?)
-        .context("Failed storing a file in the patch")?;
+    let mut index = 0;
+    for (iso_path, actual_path) in config.files.iter() {
+        add_entry_to_zip(&mut index, iso_path, actual_path, &mut zip, &mut new_map)?;
     }
     config.files = new_map;
 
@@ -274,6 +308,44 @@ fn build_patch<P: KeyValPrint>(
     Ok(())
 }
 
+fn add_file_to_iso<F: FileSource>(
+    iso_path: &String,
+    actual_path: &PathBuf,
+    iso: &mut Directory,
+    files: &mut F
+) -> Result<(), Error> {
+    iso.resolve_and_create_path(&iso_path).data = files
+        .read_to_vec(actual_path)
+        .with_context(|_| {
+            format!(
+                "Couldn't read the file \"{}\" to store it in the ISO.",
+                actual_path.display()
+            )
+        })?
+        .into();
+    Ok(())
+}
+
+fn add_entry_to_iso<F: FileSource>(
+    iso_path: &String,
+    actual_path: &PathBuf,
+    iso: &mut Directory,
+    files: &mut F
+) -> Result<(), Error> {
+    if actual_path.is_file() {
+        add_file_to_iso(iso_path, actual_path, iso, files)?;
+    } else if actual_path.is_dir() {
+        for entry in fs::read_dir(actual_path)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let file_name = entry_path.file_name().expect("Entry has no name");
+            let iso_path = String::from(iso_path) + &String::from('/') + &String::from(file_name.to_str().unwrap());
+            add_entry_to_iso(&iso_path, &entry_path, iso, files)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn build_iso<'a, P: KeyValPrint, F: FileSource>(
     printer: &P,
     mut files: F,
@@ -286,15 +358,7 @@ pub fn build_iso<'a, P: KeyValPrint, F: FileSource>(
     printer.print(None, "Replacing", "files");
 
     for (iso_path, actual_path) in &config.files {
-        iso.resolve_and_create_path(iso_path).data = files
-            .read_to_vec(actual_path)
-            .with_context(|_| {
-                format!(
-                    "Couldn't read the file \"{}\" to store it in the ISO.",
-                    actual_path.display()
-                )
-            })?
-            .into();
+        add_entry_to_iso(iso_path, actual_path, &mut iso, &mut files)?;
     }
 
     let mut original_symbols = HashMap::new();

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -383,7 +383,7 @@ pub fn build_iso<'a, P: KeyValPrint, F: FileSource>(
             .context("Couldn't patch the game")?
             .into();
     }
-    if false {
+    if iso.is_gamecube_iso() {
         printer.print(None, "Patching", "banner");
 
         if let Some(banner_file) = iso.banner_mut() {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -317,7 +317,7 @@ pub fn build_iso<'a, P: KeyValPrint, F: FileSource>(
     libs_to_link.push(compiled_library);
 
     for lib_path in config.link.libs.iter().flat_map(|x| x) {
-        let mut file_buf = files.read_to_vec(lib_path).with_context(|_| {
+        let file_buf = files.read_to_vec(lib_path).with_context(|_| {
             format!(
                 "Couldn't load \"{}\". Did you build the project correctly?",
                 lib_path.display()

--- a/backend/src/linker.rs
+++ b/backend/src/linker.rs
@@ -31,7 +31,7 @@ fn reloc_table_for_section<'a>(section_index: usize, elf: &'a Elf) -> Option<&'a
 fn function_symbols_for_section<'a>(
     section_index: usize,
     elf: &'a Elf,
-) -> Box<Iterator<Item = sym::Sym> + 'a> {
+) -> Box<dyn Iterator<Item = sym::Sym> + 'a> {
     Box::new(
         elf.syms
             .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn try_main() -> Result<(), Error> {
 
     match opt {
         Opt::Build { debug, patch, raw } => {
-            if(raw) {
+            if raw {
                 build_raw(&TermPrinter, patch).context("Couldn't build the Rom Hack")?
             } else {
                 build(&TermPrinter, debug, patch).context("Couldn't build the Rom Hack")?


### PR DESCRIPTION
This PR adds support for extracted ISO, without changing anything to the normal iso pipeline. Currently, it detects automatically if the provided path is a file or a folder, but I can change it so you have to provide an optional flag for the behaviour to kick in if it is prefered. I also added a way to check if an iso is GC or Wii, which is used to check if we can patch the banner file or not, since Wii has a totally different use for the banner file.